### PR TITLE
Encoding output correctly

### DIFF
--- a/lib/rst2parts/transform.py
+++ b/lib/rst2parts/transform.py
@@ -29,6 +29,8 @@ def transform(writer=None, part=None):
     else:
         content = sys.stdin.read()
     
+    content = content.decode(
+
     parts = publish_parts(
         source=content,
         settings_overrides=settings,
@@ -36,5 +38,5 @@ def transform(writer=None, part=None):
     )
     
     if opts.part in parts:
-        return parts[opts.part]
+        return parts[opts.part].encode(parts["encoding"])
     return ''


### PR DESCRIPTION
docutils.core.pubilsh_parts returns "html_body" part in Unicode string, at least on Python 2.6. So, at rst2html.py:16, the print statement may fail to encode the "html_body" part into default encoding when the result string contain a character which does not belongs to the character set of default encoding.

According to http://docutils.sourceforge.net/docs/api/publisher.html#publish-parts-details, all writes provide encoding part. So I wrote a patch to encode parts["html_body"] into parts["encoding"].
